### PR TITLE
External switch toggle capability

### DIFF
--- a/arduino/ESPsonoff-v1.01pOTA/ESPsonoff-v1.01pOTA.ino
+++ b/arduino/ESPsonoff-v1.01pOTA/ESPsonoff-v1.01pOTA.ino
@@ -98,8 +98,11 @@ void setup() {
   pinMode(LED, OUTPUT);
   pinMode(RELAY, OUTPUT);
   pinMode(BUTTON, INPUT);
+  pinMode(WALL_SWITCH, OUTPUT);
   digitalWrite(LED, HIGH);
   digitalWrite(RELAY, LOW);
+  digitalWrite(WALL_SWITCH, HIGH);
+  lastSwitchState = 1;
   Serial.begin(115200);
   EEPROM.begin(8);
   lastRelayState = EEPROM.read(0);

--- a/arduino/ESPsonoff-v1.01pOTA/ESPsonoff-v1.01pOTA.ino
+++ b/arduino/ESPsonoff-v1.01pOTA/ESPsonoff-v1.01pOTA.ino
@@ -42,6 +42,7 @@
 #define BUTTON          0                                    // (Don't Change for Original Sonoff, Sonoff SV, Sonoff Touch, Sonoff S20 Socket)
 #define RELAY           12                                   // (Don't Change for Original Sonoff, Sonoff SV, Sonoff Touch, Sonoff S20 Socket)
 #define LED             13                                   // (Don't Change for Original Sonoff, Sonoff SV, Sonoff Touch, Sonoff S20 Socket)
+#define WALL_SWITCH     14
 
 #define MQTT_CLIENT     "Sonoff_Living_Room_v1.01pOTA"       // mqtt client_id (Must be unique for each Sonoff)
 #define MQTT_SERVER     "192.168.0.100"                      // mqtt server
@@ -63,6 +64,7 @@ bool requestRestart = false;                                 // (Do not Change)
 int kUpdFreq = 1;                                            // Update frequency in Mintes to check for mqtt connection
 int kRetries = 10;                                           // WiFi retry count. Increase if not connecting to router.
 int lastRelayState;                                          // (Do not Change)
+int lastSwitchState;
 
 unsigned long TTasks;                                        // (Do not Change)
 unsigned long count = 0;                                     // (Do not Change)
@@ -184,6 +186,7 @@ void loop() {
   if (OTAupdate == false) { 
     mqttClient.loop();
     timedTasks();
+    checkExternalSwitch();
     checkStatus();
   }
 }
@@ -228,6 +231,15 @@ void checkConnection() {
   else { 
     Serial.println("WiFi connection . . . . . . . . . . LOST");
     requestRestart = true;
+  }
+}
+
+void checkExternalSwitch() {
+  if (digitalRead(WALL_SWITCH) != lastSwitchState)  {
+    digitalWrite(LED, !digitalRead(LED));
+    digitalWrite(RELAY, !digitalRead(RELAY));
+    lastSwitchState = !lastSwitchState;
+    sendStatus = true;
   }
 }
 


### PR DESCRIPTION
Added capability to connect an external switch to Sonoff GPIO14 pin in order to be able to togle the relay state, this is useful to conect the Sonoff to a wall toggle switch and be able to togle the relay state through wifi & direct wall switch as if it was a normal switch.
The wall switch will act as a togle so if you use the wall switch tu turn on then use wifi to turn off the wall switch then would toggle to On again.

Conect wall switch to GND pin & other conector to GPIO14 (switch should not have voltage)
![sonoff_gpio-r](https://cloud.githubusercontent.com/assets/17080292/26805594/e14b88de-4a4c-11e7-8b61-b5f4aaa9e385.jpg)
